### PR TITLE
fixed cors issues calling an axios.post() from front-end

### DIFF
--- a/client/src/Components/ProfileContent/ProfileContent.jsx
+++ b/client/src/Components/ProfileContent/ProfileContent.jsx
@@ -2,13 +2,24 @@ import React from "react";
 import "./ProfileContent.scss";
 import Stats from "../Stats/Stats";
 import SavedPlaylists from "../SavedPlaylists/SavedPlaylists";
+import axios from "axios";
 
 function ProfileContent({ header }) {
   const contentSection =
     header === "Playlists" ? <SavedPlaylists /> : <Stats />;
+  const test = async () => {
+    const { data } = await axios.post(
+      "http://localhost:8080/test",
+      {},
+      { withCredentials: true }
+    );
+  };
   return (
     <div className="profile-content">
       <h1 className="profile-content__header">{header.toUpperCase()}</h1>
+      <button style={{ border: "1px solid black" }} onClick={() => test()}>
+        TEST
+      </button>
       <section className="profile-content__content-section">
         {contentSection}
       </section>

--- a/server/server.js
+++ b/server/server.js
@@ -104,7 +104,7 @@ app.get('/refresh', (req, res, next) => {
 });
 
 app.post('/test', (req, res) => {
-  console.log(req.user);
+  console.log('the req user is: ', req.user);
   res.status(200).json(req.user);
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -14,11 +14,6 @@ const axios = require('axios');
 
 const knex = require('knex')(require('./knexfile.js').development);
 
-app.use(express.json());
-app.use(cors());
-
-app.use(helmet());
-
 app.use(
   cors({
     origin: true,
@@ -33,6 +28,9 @@ app.use(
     saveUninitialized: true,
   })
 );
+
+app.use(express.json());
+app.use(helmet());
 
 app.use(passport.initialize());
 app.use(passport.session());

--- a/server/server.js
+++ b/server/server.js
@@ -103,6 +103,11 @@ app.get('/refresh', (req, res, next) => {
   );
 });
 
+app.post('/test', (req, res) => {
+  console.log(req.user);
+  res.status(200).json(req.user);
+});
+
 app.post('/embed', (req, res, next) => {
   const render_oEmbed = async () => {
     const base_uri = 'https://open.spotify.com/oembed';


### PR DESCRIPTION
fixed issue when calling a POST endpoint from backend using axios.post() from frontend
- extra `app.use(cors())` was deleted
- re-ordered session and cors (with options) middlewares

*no test functionality implemented on this branch*
you can test functionality by checking out the `protected-ep` branch locally by:
`git fetch; git checkout protected-ep`
- go through steps from Discover page and press the 'testendpoint' button at the end
- you will have a dummy playlist 'posttestpl' created in your spotify account